### PR TITLE
Add Virtual deconstructor for ITransportLayer in itransport_layer.h

### DIFF
--- a/Source/ROSIntegration/Private/rosbridge2cpp/itransport_layer.h
+++ b/Source/ROSIntegration/Private/rosbridge2cpp/itransport_layer.h
@@ -14,7 +14,8 @@ namespace rosbridge2cpp {
 	class ITransportLayer {
 	public:
 		enum TransportMode { JSON, BSON };
-
+		virtual ~ITransportLayer() = default;
+		
 		// Initialize the TransportLayer by connecting to the given IP and port
 		// The implementing class should have an active connection to IP:port
 		// when the method has been executed completly.


### PR DESCRIPTION
fixes "error: delete called on non-final 'TCPConnection' that has virtual functions but non-virtual" when building for UE 5.2